### PR TITLE
Revert "update worker syntax"

### DIFF
--- a/js/worker.mjs
+++ b/js/worker.mjs
@@ -4,19 +4,22 @@ import mod from "../dist/app.wasm";
 
 const go = new Go();
 
-const readyPromise = new Promise((resolve) => {
-  globalThis.ready = resolve;
-});
-
 const load = WebAssembly.instantiate(mod, go.importObject).then((instance) => {
   go.run(instance);
   return instance;
 });
 
-export default {
-  async fetch(req, env, ctx) {
-    await load;
-    await readyPromise;
-    return handleRequest(req, { env, ctx });
-  }
+const readyPromise = new Promise((resolve) => {
+  globalThis.ready = resolve;
+});
+
+async function processRequest(event) {
+  const req = event.request;
+  await load;
+  await readyPromise;
+  return handleRequest(req);
 }
+
+addEventListener("fetch", (event) => {
+  event.respondWith(processRequest(event));
+})


### PR DESCRIPTION
Reverts syumai/worker-template-go#1

* Module Worker syntax seems to be unable to run Go worker (tinygo worker can).
* To investigate it, revert Module Worker.